### PR TITLE
[Bugfix] Change the URL the user is redirected to after creating a new request to be valid

### DIFF
--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -77,7 +77,7 @@ class SubmitController
         $this->inputDetails = (string) $this->paramPost($request, 'details');
 
         if (($srpRequest = $this->createSrpRequest()) !== null) {
-            return $response->withHeader('Location', "/request/{$srpRequest->getId()}/show");
+            return $response->withHeader('Location', "/request/{$srpRequest->getId()}");
         } else {
             return $this->showForm($request, $response);
         }


### PR DESCRIPTION
Currently when the user creates an SRP request it takes them to `request/<user id>/show`, which results in a 404 page since this route isn't present in the routes file. 

Bug Replication:
https://i.imgur.com/Q7GyeC0.gif

This PR changes the path that the Submit Controller redirects the user to `request/<user id>` instead after they create their request.

Fix:
https://i.imgur.com/JPeJQqR.gif