### PR TITLE
[Content] Changed the labels for the Submitted and Kill time fields to be more consistent between the request list and request details pages

### DIFF
--- a/templates/components/request-list.twig
+++ b/templates/components/request-list.twig
@@ -14,7 +14,7 @@
                 <th>System</th>
                 <th>Kill Time</th>
                 <th>External URLs</th>
-                <th>Submitted <i class="bi bi-sort-{{ sort }} float-end"></i></th>
+                <th>Submitted Time <i class="bi bi-sort-{{ sort }} float-end"></i></th>
                 <th>Division</th>
                 <th>Status</th>
                 <th class="text-end">Payout</th>

--- a/templates/pages/parts/request--data.twig
+++ b/templates/pages/parts/request--data.twig
@@ -10,7 +10,7 @@
         </td>
     </tr>
     <tr>
-        <th>Submitted</th>
+        <th>Submited Time</th>
         <td>{{ request.created|date('Y-m-d H:i e') }}</td>
     </tr>
     <tr>
@@ -35,7 +35,7 @@
         </td>
     </tr>
     <tr>
-        <th>Date and time</th>
+        <th>Kill Time</th>
         <td>{{ request.killTime|date('Y-m-d H:i e') }}</td>
     </tr>
     <tr>


### PR DESCRIPTION
Currently the Request List page uses the terminology "Kill Time" and "Submitted" while the Request Details pages uses the terminology "Date and time" and "Submitted".

![image](https://user-images.githubusercontent.com/74442922/232392587-8fce4c6f-37ba-4ad8-913c-4993266d12ed.png)
![image](https://user-images.githubusercontent.com/74442922/232392543-34e945c3-67a1-48e4-a65f-fa20b963caac.png)

This PR switches both of them to use the "Kill Time" and "Submitted Time" terminology for consistency to make sure that people don't get confused by these fields.

![image](https://user-images.githubusercontent.com/74442922/232392830-55a1e87d-7d66-4d8f-a6c9-f8ecc58f1fc3.png)
![image](https://user-images.githubusercontent.com/74442922/232392803-36ba670d-bba2-43dc-ac76-303ab3e1feaa.png)
