### PR TITLE
[Enhancement] Change page title to a link to the home page

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -3,7 +3,7 @@
 {% block main %}
     <header class="navbar navbar-dark border-bottom mb-3 navbar-expand-lg">
         <div class="container-fluid">
-            <span class="navbar-brand">{{ data.appTitle }}</span>
+            <a class="nav-link navbar-brand" href="/"><span>{{ data.appTitle }}</span></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navBarToggle" aria-controls="navBarToggle"
                     aria-expanded="false" aria-label="Toggle navigation">

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -3,7 +3,7 @@
 {% block main %}
     <header class="navbar navbar-dark border-bottom mb-3 navbar-expand-lg">
         <div class="container-fluid">
-            <a class="nav-link navbar-brand" href="/"><span>{{ data.appTitle }}</span></a>
+            <a class="nav-link navbar-brand" href="/">{{ data.appTitle }}</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navBarToggle" aria-controls="navBarToggle"
                     aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Currently the page title at the top left of the screen is just text that doesn't do anything. Most web apps have their page title link back to their home page, so most users expect this functionality to be present.

This PR changes the page title to be a link to the home page.
Visually it looks the same as before, so this change only adds the linking behavior.

Gif showing the new experience: https://i.imgur.com/IeGgH0T.gif
 
Proposed:
![image](https://user-images.githubusercontent.com/74442922/232394329-3c9daee6-fc42-427e-8043-a13236661bfb.png)
Existing:
![image](https://user-images.githubusercontent.com/74442922/232394359-3208b965-1dfa-476a-b7d3-df9a3d622959.png)
