### PR TITLE
[Enhancement] Change timestamp values to link to Nakamura Labs

### DIFF
--- a/templates/components/request-list.twig
+++ b/templates/components/request-list.twig
@@ -26,7 +26,11 @@
                 <td><a href="/request/{{ request.id }}">{{ request.ship }}</a></td>
                 <td>{{ request.character.name }}</td>
                 <td>{{ request.solarSystem }}</td>
-                <td>{{ request.killTime|date('Y-m-d H:i') }}</td>
+                <td>
+                    {% include 'components/timestamp.twig' with {
+                        'timestamp': request.killTime,
+                    } only %}
+                </td>
                 <td>
                     {% if request.killboardUrl %}
                         <a href="{{ request.killboardUrl }}" target="_blank" rel="noopener noreferrer"
@@ -38,7 +42,11 @@
                            class="srp-external-link">ESI</a>
                     {% endif %}
                 </td>
-                <td>{{ request.created|date('Y-m-d H:i') }}</td>
+                <td>
+                    {% include 'components/timestamp.twig' with {
+                        'timestamp': request.created
+                    } only %}
+                </td>
                 <td>{{ request.division.name }}</td>
                 <td>{{ request.status }}</td>
                 <td class="text-end">

--- a/templates/components/timestamp.twig
+++ b/templates/components/timestamp.twig
@@ -1,0 +1,8 @@
+<a 
+    href="https://time.nakamura-labs.com/?#{{ timestamp|date('U') }}" 
+    target="_blank" 
+    rel="noopener noreferrer"
+    class="srp-external-link"
+>
+    {{ timestamp|date(format|default('Y-m-d H:i')) }}
+</a>

--- a/templates/pages/parts/request--data.twig
+++ b/templates/pages/parts/request--data.twig
@@ -11,7 +11,12 @@
     </tr>
     <tr>
         <th>Submitted</th>
-        <td>{{ request.created|date('Y-m-d H:i e') }}</td>
+        <td>
+            {% include 'components/timestamp.twig' with {
+                'timestamp': request.created,
+                'format': 'Y-m-d H:i e'
+            } only %}
+        </td>
     </tr>
     <tr>
         <th>Pilot</th>
@@ -36,7 +41,12 @@
     </tr>
     <tr>
         <th>Date and time</th>
-        <td>{{ request.killTime|date('Y-m-d H:i e') }}</td>
+        <td>
+            {% include 'components/timestamp.twig' with {
+                'timestamp': request.killTime,
+                'format': 'Y-m-d H:i e'
+            } only %}
+        </td>
     </tr>
     <tr>
         <th>Solar system</th>


### PR DESCRIPTION
Currently we show timestamps in a couple of different spots throughout the app, such as on the Request List and Request Details pages. These timestamps are helpful when processing SRP requests but they're sometimes hard to compare to relative time value from other sources (such as Discord and Slack pings sent without the ping tool) meaning that you have to manually plugin the relative time value into Nakamura labs to be able to compare the two values.

This PR changes these timestamp fields to link to a Nakamura Labs page with that specific timestamp already plugged in to reduce the amount of work required in this process. It also offers a new default date time format so that we don't have to specify it everyone in the app, but it does still allow it's consumers to change the format if they want to.

Here's a GIF of showing off this new component. 
https://i.imgur.com/WMf0xRE.gif

The text and format for these timestamp fields are identical to what they currently are in the app, with the only change right now being to turn them into links.