### PR TITLE
[Bugfix] Fixed an issue where requests without an existing base payout couldn't be updated

### DIFF
--- a/src/Controller/RequestController.php
+++ b/src/Controller/RequestController.php
@@ -331,10 +331,17 @@ class RequestController
             $action->setCreated(new \DateTime());
             $action->setUser($this->userService->getAuthenticatedUser());
             $action->setCategory(Type::COMMENT);
-            $action->setNote(
-                'Changed base payout from  ' . number_format($oldPayout) . ' to ' .
-                number_format($newBasePayout) . ' ISK.'
-            );
+
+            if ($oldPayout === null) {
+                $action->setNote(
+                    'Set base payout to ' . number_format($newBasePayout) . ' ISK.'
+                );
+            } else {
+                $action->setNote(
+                    'Changed base payout from ' . number_format($oldPayout) . ' to ' .
+                    number_format($newBasePayout) . ' ISK.'
+                );
+            }
 
             $action->setRequest($request);
             $this->entityManager->persist($action);


### PR DESCRIPTION
There is currently a bug where if you make a new request and then attempt to update it's payout that causes the backend to throw an error. https://i.imgur.com/0fkv2ts.gif

This error is being caused because when the controller attempts to add a comment to the request talking about that new payout amount, it assumes that the old base payout amount was not-null, which is not the case when a request has just been made.

This PR changes the save method for the requests in the `RequestController` to check if the existing base payout has already been set and if so, it creates a comment using the current functionality but if not, it makes a comment that doesn't use the existing base payout (since it didn't exist before). 
https://i.imgur.com/BhCySL2.gif