### PR TITLE
[Enhancement] Added a summation of the total payouts on the request list page

### DIFF
--- a/resources/eve-srp.scss
+++ b/resources/eve-srp.scss
@@ -66,6 +66,15 @@ a {
     background-color: var(--srp-bg-color-2);
 }
 
+.srp-text {
+    color: var(--srp-text-color);
+}
+
+.srp-list-caption {
+    caption-side: bottom;
+    text-align: center;
+}
+
 // Libraries
 
 .form-control,

--- a/resources/eve-srp.scss
+++ b/resources/eve-srp.scss
@@ -70,11 +70,6 @@ a {
     color: var(--srp-text-color);
 }
 
-.srp-list-caption {
-    caption-side: bottom;
-    text-align: center;
-}
-
 // Libraries
 
 .form-control,

--- a/templates/components/request-list.twig
+++ b/templates/components/request-list.twig
@@ -49,6 +49,17 @@
             </tr>
         {%  endfor %}
         </tbody>
+        <caption class="srp-list-caption">
+            <span class="srp-text">
+                {{ requests|length }} Requests for a total of 
+                    {% set totalPayoutsAmount = 0 %}
+                    {% for request in requests %}
+                        {% set totalPayoutsAmount = totalPayoutsAmount + request.payout %}
+                        {% if loop.last %}{{ totalPayoutsAmount|number_format }}{% endif %}
+                    {% endfor %}
+                ISK
+            </span>
+        </caption>
     </table>
 </div>
 

--- a/templates/components/request-list.twig
+++ b/templates/components/request-list.twig
@@ -49,7 +49,7 @@
             </tr>
         {%  endfor %}
         </tbody>
-        <caption class="srp-list-caption">
+        <caption class="text-center">
             <span class="srp-text">
                 {{ requests|length }} Requests for a total of 
                     {% set totalPayoutsAmount = 0 %}


### PR DESCRIPTION
When communicating with high-level SRP stakeholders, such as Directors and finance personalle, it's nice to be able to easily quantify how many requests we have and for how much ISK is needed to pay them all out. We use this information to do things like quantify losses for fights and to know how much ISK we need to request when refilling SRP payout wallets.

This PR adds a caption to the request list tables quantifying information for the requests that are shown in the table such as how many requests are in the table and how much ISK they represent. 
![image](https://user-images.githubusercontent.com/74442922/232738626-25bce89f-3097-4762-b81a-3f21bd3e5103.png)

Note: This change won't work with server-side paging, such as what is used on the All Requests page, so for now on those screens it'll only quantify information for the requests that are included in those pages. While quantifying all of the information across the pages would be nice, it's not essential since we typically don't need that information and when we do, having the totals for each page and adding them up manually would suffice, so I think not changing the backend for now would be acceptable. 