### PR TITLE
Fixed an issue where ESI killmail links don't have a trailing slash

### DIFF
--- a/src/Service/ApiService.php
+++ b/src/Service/ApiService.php
@@ -97,7 +97,7 @@ class ApiService
     public function getEsiKillUrl(int $killId, string $hash): string
     {
         if ($hash) {
-            return "{$this->getEsiKillUrlBase()}$killId/$hash";
+            return "{$this->getEsiKillUrlBase()}$killId/$hash/";
         }
         return '';
     }


### PR DESCRIPTION
This PR fixes an issue where we weren't adding a trailing backslash after the ESI link, which caused issues if you tried to post it to Zkill. 
Basically Zkill has a really weird quirk where if you don't add a backslash to things (whether it be an call to the Zkill API or apparently an ESI killmail link you're trying to post) that it just won't do anything intentionally. This is why in the `getKillboardUrl` method we're adding a trailing slash, because otherwise Zkill wouldn't pull up the killmail. We're basically just adding that behavior to `getEsiKillUrl` as well. 

Here's a GIF showing this issue in action with the live version of the SRP app:
![new_srp_app_zkill_esi_link_post](https://github.com/tkhamez/eve-srp/assets/74442922/373827c6-cf1d-4a67-be40-4ed6bccba8e4)
